### PR TITLE
Added section to README that details the acronyms

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@ National Insurance and State Pension
 
 [![Build Status](https://travis-ci.org/hmrc/nisp.svg)](https://travis-ci.org/hmrc/nisp) [ ![Download](https://api.bintray.com/packages/hmrc/releases/nisp/images/download.svg) ](https://bintray.com/hmrc/releases/nisp/_latestVersion)
 
-This microservice retrieves data from a [HoD](http://webarchive.nationalarchives.gov.uk/+/http://www.hmrc.gov.uk/manuals/sam/samglossary/samgloss249.htm) system called "NPS", for calculating State Pension Age and Amount.
+This microservice retrieves data from a [HoD] system called [NPS], for calculating State Pension Age and Amount.
 
 Requirements
 ------------
 
-This service is written in [Scala](http://www.scala-lang.org/) and [Play](http://playframework.com/), so needs at least a [JRE](http://www.oracle.com/technetwork/java/javase/downloads/index.html) to run.
+This service is written in [Scala](http://www.scala-lang.org/) and [Play](http://playframework.com/), so needs at least a [JRE] to run.
 
 API
 ---
@@ -31,7 +31,7 @@ Fetches the SPResponseModel object for the frontend service.
 
   `nino=[nino]`
 
-  The NINO given must be a valid NINO: ([http://www.hmrc.gov.uk/manuals/nimmanual/nim39110.htm](http://www.hmrc.gov.uk/manuals/nimmanual/nim39110.htm))
+  The [NINO] given must be a valid [NINO].
 
 * **Success Response:**
 
@@ -115,7 +115,7 @@ Fetches the NIResponseModel object for the frontend service.
 
   `nino=[nino]`
 
-  The NINO given must be a valid NINO: ([http://www.hmrc.gov.uk/manuals/nimmanual/nim39110.htm](http://www.hmrc.gov.uk/manuals/nimmanual/nim39110.htm))
+  The [NINO] given must be a valid [NINO]
 
 * **Success Response:**
 
@@ -277,7 +277,7 @@ Fetches the NIResponseModel object for the frontend service.
 Configuration
 ---
 
-This service requires configuration for other services, for example NPS requires:
+This service requires configuration for other services, for example [NPS] requires:
 
 | *Key*                                    | *Description*                   |
 | ---------------------------------------- | ---------------------------     |
@@ -285,8 +285,40 @@ This service requires configuration for other services, for example NPS requires
 | `microservice.services.nps-hod.host`     | The host of the NPS service     |
 | `microservice.services.nps-hod.port`     | The port of the NPS service     |
 
+Acronyms
+---
+
+In the context of this application we use the following acronyms and define their 
+meanings. Provided you will also find a web link to discover more about the systems
+and technology. 
+
+* [API]: Application Programming Interface
+
+* [HoD]: Head of Duty
+
+* [JRE]: Java Runtime Environment
+
+* [JSON]: JavaScript Object Notation
+
+* [NI]: National Insurance 
+
+* [NINO]: National Insurance Number
+
+* [NPS]: National Insurance and Pay As You Earn Service
+
+* [URL]: Uniform Resource Locator
+
 License
 ---
 
 This code is open source software licensed under the [Apache 2.0 License]("http://www.apache.org/licenses/LICENSE-2.0.html").
 
+
+[NPS]: http://www.publications.parliament.uk/pa/cm201012/cmselect/cmtreasy/731/73107.htm
+[HoD]: http://webarchive.nationalarchives.gov.uk/+/http://www.hmrc.gov.uk/manuals/sam/samglossary/samgloss249.htm
+[NINO]: http://www.hmrc.gov.uk/manuals/nimmanual/nim39110.htm
+[NI]: https://www.gov.uk/national-insurance/overview
+[JRE]: http://www.oracle.com/technetwork/java/javase/overview/index.html
+[API]: https://en.wikipedia.org/wiki/Application_programming_interface
+[URL]: https://en.wikipedia.org/wiki/Uniform_Resource_Locator
+[JSON]: http://www.json.org/


### PR DESCRIPTION
At the bottom of the README a list of references and the appropriate link.
Then within the document you wrap the acronym in [] to use the link
provided.

Therefore it only has to be changed in one location. This is the current
STRICT markdown syntax that should be used to be XHTML compliant.

The weather is dark and rainy and my coffee mug is empty...