### PR TITLE
NISP-2060: Address TTL Index issues in MongoDB

### DIFF
--- a/app/uk/gov/hmrc/nisp/cache/LiabilitiesRepository.scala
+++ b/app/uk/gov/hmrc/nisp/cache/LiabilitiesRepository.scala
@@ -29,8 +29,8 @@ import uk.gov.hmrc.nisp.models.enums.APITypes
 import uk.gov.hmrc.nisp.models.enums.APITypes.APITypes
 
 case class LiabilitiesCacheModel(key: String,
-                             response: NpsLiabilityContainer,
-                             createdAt: DateTime = DateTime.now(DateTimeZone.UTC))
+                                 response: NpsLiabilityContainer,
+                                 expiresAt: DateTime)
   extends CachingModel[LiabilitiesCacheModel, NpsLiabilityContainer] {
 }
 

--- a/app/uk/gov/hmrc/nisp/cache/LiabilitiesRepository.scala
+++ b/app/uk/gov/hmrc/nisp/cache/LiabilitiesRepository.scala
@@ -35,6 +35,8 @@ case class LiabilitiesCacheModel(key: String,
 }
 
 object LiabilitiesCacheModel {
+  implicit val dateFormat = ReactiveMongoFormats.dateTimeFormats
+  implicit val idFormat = ReactiveMongoFormats.objectIdFormats
   implicit def formats = Json.format[LiabilitiesCacheModel]
 }
 

--- a/app/uk/gov/hmrc/nisp/cache/NationalInsuranceRepository.scala
+++ b/app/uk/gov/hmrc/nisp/cache/NationalInsuranceRepository.scala
@@ -28,8 +28,8 @@ import uk.gov.hmrc.nisp.models.nps.NpsNIRecordModel
 import uk.gov.hmrc.nisp.services.{CachingModel, CachingMongoService}
 
 case class NationalInsuranceCacheModel(key: String,
-                             response: NpsNIRecordModel,
-                             createdAt: DateTime = DateTime.now(DateTimeZone.UTC))
+                                       response: NpsNIRecordModel,
+                                       expiresAt: DateTime)
   extends CachingModel[NationalInsuranceCacheModel, NpsNIRecordModel] {
 }
 

--- a/app/uk/gov/hmrc/nisp/cache/NationalInsuranceRepository.scala
+++ b/app/uk/gov/hmrc/nisp/cache/NationalInsuranceRepository.scala
@@ -20,6 +20,7 @@ import org.joda.time.{DateTime, DateTimeZone}
 import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json.Json
 import play.modules.reactivemongo.MongoDbConnection
+import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
 import uk.gov.hmrc.nisp.config.ApplicationConfig
 import uk.gov.hmrc.nisp.metrics.Metrics
 import uk.gov.hmrc.nisp.models.enums.APITypes
@@ -33,6 +34,8 @@ case class NationalInsuranceCacheModel(key: String,
 }
 
 object NationalInsuranceCacheModel {
+  implicit val dateFormat = ReactiveMongoFormats.dateTimeFormats
+  implicit val idFormat = ReactiveMongoFormats.objectIdFormats
   implicit def formats = Json.format[NationalInsuranceCacheModel]
 }
 

--- a/app/uk/gov/hmrc/nisp/cache/SchemeMembershipRepository.scala
+++ b/app/uk/gov/hmrc/nisp/cache/SchemeMembershipRepository.scala
@@ -28,8 +28,8 @@ import uk.gov.hmrc.nisp.models.nps.NpsSchemeMembershipContainer
 import uk.gov.hmrc.nisp.services.{CachingModel, CachingMongoService}
 
 case class SchemeMembershipCacheModel(key: String,
-                             response: NpsSchemeMembershipContainer,
-                             createdAt: DateTime = DateTime.now(DateTimeZone.UTC))
+                                      response: NpsSchemeMembershipContainer,
+                                      expiresAt: DateTime)
   extends CachingModel[SchemeMembershipCacheModel, NpsSchemeMembershipContainer] {
 }
 

--- a/app/uk/gov/hmrc/nisp/cache/SchemeMembershipRepository.scala
+++ b/app/uk/gov/hmrc/nisp/cache/SchemeMembershipRepository.scala
@@ -20,6 +20,7 @@ import org.joda.time.{DateTime, DateTimeZone}
 import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json.Json
 import play.modules.reactivemongo.MongoDbConnection
+import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
 import uk.gov.hmrc.nisp.config.ApplicationConfig
 import uk.gov.hmrc.nisp.metrics.Metrics
 import uk.gov.hmrc.nisp.models.enums.APITypes
@@ -33,6 +34,8 @@ case class SchemeMembershipCacheModel(key: String,
 }
 
 object SchemeMembershipCacheModel {
+  implicit val dateFormat = ReactiveMongoFormats.dateTimeFormats
+  implicit val idFormat = ReactiveMongoFormats.objectIdFormats
   implicit def formats = Json.format[SchemeMembershipCacheModel]
 }
 

--- a/app/uk/gov/hmrc/nisp/cache/SummaryRepository.scala
+++ b/app/uk/gov/hmrc/nisp/cache/SummaryRepository.scala
@@ -29,7 +29,7 @@ import uk.gov.hmrc.nisp.services.{CachingModel, CachingMongoService}
 
 case class SummaryCacheModel(key: String,
                              response: NpsSummaryModel,
-                             createdAt: DateTime = DateTime.now(DateTimeZone.UTC))
+                             expiresAt: DateTime)
   extends CachingModel[SummaryCacheModel, NpsSummaryModel]
 
 object SummaryCacheModel {

--- a/app/uk/gov/hmrc/nisp/cache/SummaryRepository.scala
+++ b/app/uk/gov/hmrc/nisp/cache/SummaryRepository.scala
@@ -20,6 +20,7 @@ import org.joda.time.{DateTime, DateTimeZone}
 import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json.Json
 import play.modules.reactivemongo.MongoDbConnection
+import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
 import uk.gov.hmrc.nisp.config.ApplicationConfig
 import uk.gov.hmrc.nisp.metrics.Metrics
 import uk.gov.hmrc.nisp.models.enums.APITypes
@@ -32,6 +33,8 @@ case class SummaryCacheModel(key: String,
   extends CachingModel[SummaryCacheModel, NpsSummaryModel]
 
 object SummaryCacheModel {
+  implicit val dateFormat = ReactiveMongoFormats.dateTimeFormats
+  implicit val idFormat = ReactiveMongoFormats.objectIdFormats
   implicit def formats = Json.format[SummaryCacheModel]
 }
 

--- a/app/uk/gov/hmrc/nisp/config/ApplicationConfig.scala
+++ b/app/uk/gov/hmrc/nisp/config/ApplicationConfig.scala
@@ -25,7 +25,7 @@ trait ApplicationConfig {
 }
 
 object ApplicationConfig extends ApplicationConfig with ServicesConfig {
-  override val responseCacheTTL = getConfInt("mongodb.responseTTL", 600)
+  override val responseCacheTTL = configuration.getInt("mongodb.responseTTL").getOrElse(throw new RuntimeException("MongoDB TTL is not configured"))
 }
 
 

--- a/app/uk/gov/hmrc/nisp/services/CachingService.scala
+++ b/app/uk/gov/hmrc/nisp/services/CachingService.scala
@@ -24,7 +24,6 @@ import reactivemongo.api.{DefaultDB, ReadPreference}
 import reactivemongo.bson.{BSONDocument, BSONObjectID}
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.mongo.ReactiveRepository
-import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
 import uk.gov.hmrc.nisp.config.ApplicationConfig
 import uk.gov.hmrc.nisp.metrics.Metrics
 import uk.gov.hmrc.nisp.models.enums.APITypes._
@@ -36,8 +35,6 @@ trait CachingModel[A, B] {
   val key: String
   val response: B
   val createdAt: DateTime
-  implicit val dateFormat = ReactiveMongoFormats.dateTimeFormats
-  implicit val idFormat = ReactiveMongoFormats.objectIdFormats
 }
 
 trait CachingService[A, B] {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -93,5 +93,5 @@ microservice {
 
 mongodb {
   uri = "mongodb://localhost:27017/nisp"
-  responseTTL = 1200
+  responseTTL = 60
 }


### PR DESCRIPTION
This PR address our MongoDB problem.
* The problem was to do with `createdAt` being resolved to Longs rather than dates. Moving the `implicits` to the individual classes seems to have fixed this issue.
* An issue to do with the TTL in the application.conf not being read has been fixed.
* The default TTL in the application.conf file is now 60 seconds to allow for easier debugging / testing.
* The `createdAt` field has been removed for a `expiresAt` field. The `expiresAt` field will be equal to the current time + the `responseTTL` seconds in the config. The actual index has `expireAfterSeconds` set to `0`, this will allow us to change the time in future deployments without having to drop and re-create the index.

This is a breaking change, so the MongoDB database will need to be dropped before deployments / running locally.