### PR TITLE
NISP-2068: Replace insert with upsert

### DIFF
--- a/test/uk/gov/hmrc/nisp/cache/LiabilitiesRepositorySpec.scala
+++ b/test/uk/gov/hmrc/nisp/cache/LiabilitiesRepositorySpec.scala
@@ -81,6 +81,11 @@ class LiabilitiesRepositorySpec extends UnitSpec with OneServerPerSuite with Mon
       found shouldBe None
     }
 
+    "multiple calls to insertByNino should be fine (upsert)" in {
+      await(service.insertByNino(TestAccountBuilder.regularNino, testLiablitiesModel)) shouldBe true
+      await(service.insertByNino(TestAccountBuilder.regularNino, testLiablitiesModel)) shouldBe true
+    }
+
   }
 
 

--- a/test/uk/gov/hmrc/nisp/cache/NationalInsuranceRepositorySpec.scala
+++ b/test/uk/gov/hmrc/nisp/cache/NationalInsuranceRepositorySpec.scala
@@ -91,6 +91,10 @@ class NationalInsuranceRepositorySpec extends UnitSpec with OneServerPerSuite wi
       found shouldBe None
     }
 
+    "multiple calls to insertByNino should be fine (upsert)" in {
+      await(service.insertByNino(TestAccountBuilder.regularNino, testNIModel)) shouldBe true
+      await(service.insertByNino(TestAccountBuilder.regularNino, testNIModel)) shouldBe true
+    }
   }
 
 

--- a/test/uk/gov/hmrc/nisp/cache/SchemeMembershipRepositorySpec.scala
+++ b/test/uk/gov/hmrc/nisp/cache/SchemeMembershipRepositorySpec.scala
@@ -80,6 +80,11 @@ class SchemeMembershipRepositorySpec extends UnitSpec with OneServerPerSuite wit
       found shouldBe None
     }
 
+    "multiple calls to insertByNino should be fine (upsert)" in {
+      await(service.insertByNino(TestAccountBuilder.regularNino, testSchemeMembershipModel)) shouldBe true
+      await(service.insertByNino(TestAccountBuilder.regularNino, testSchemeMembershipModel)) shouldBe true
+    }
+
   }
 
 

--- a/test/uk/gov/hmrc/nisp/cache/SummaryRepositorySpec.scala
+++ b/test/uk/gov/hmrc/nisp/cache/SummaryRepositorySpec.scala
@@ -126,6 +126,11 @@ class SummaryRepositorySpec extends UnitSpec with OneServerPerSuite with MongoSp
       found shouldBe None
     }
 
+    "multiple calls to insertByNino should be fine (upsert)" in {
+      await(service.insertByNino(TestAccountBuilder.regularNino, testSummaryModel)) shouldBe true
+      await(service.insertByNino(TestAccountBuilder.regularNino, testSummaryModel)) shouldBe true
+    }
+
   }
 
 


### PR DESCRIPTION
This replaces insert with upsert, which will help the duplicate key exceptions we have been having in production because of race conditions.
The unique key still exists so this will not cause duplicate document insertions.
