### PR TITLE
NISP-1982: Filter out duplicate SchemeMembership Occurences

### DIFF
--- a/app/uk/gov/hmrc/nisp/controllers/SchemeMembershipController.scala
+++ b/app/uk/gov/hmrc/nisp/controllers/SchemeMembershipController.scala
@@ -21,7 +21,6 @@ import play.api.mvc.{Action, AnyContent}
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.nisp.services.SchemeMembershipService
 import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext._
-import com.github.nscala_time.time.OrderingImplicits._
 import uk.gov.hmrc.play.microservice.controller.BaseController
 
 object SchemeMembershipController extends SchemeMembershipController {
@@ -35,7 +34,7 @@ trait SchemeMembershipController extends BaseController with ErrorHandling {
 
   def getSchemeSummary(nino: Nino): Action[AnyContent] = Action.async {
     implicit request => errorWrapper(nino, {
-      schemeService.getSchemeSummary(nino).map(schemeResponse => Ok(Json.toJson(schemeResponse.sortBy(_.schemeStartDate).reverse)))
+      schemeService.getSchemeSummary(nino).map(schemeResponse => Ok(Json.toJson(schemeResponse)))
     })
   }
 }

--- a/app/uk/gov/hmrc/nisp/models/nps/NpsSchemeMembership.scala
+++ b/app/uk/gov/hmrc/nisp/models/nps/NpsSchemeMembership.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.nisp.models.nps
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
-case class NpsSchemeMembership(startDate: NpsDate, endDate: Option[NpsDate]) {
+case class NpsSchemeMembership(startDate: NpsDate, endDate: Option[NpsDate], sequenceNumber: Int, occurrenceNumber: Int) {
   def contains(npsDate: NpsDate): Boolean = {
     (startDate, endDate) match {
       case (start, None) => npsDate.localDate.isAfter(start.localDate) || npsDate.localDate.isEqual(start.localDate)
@@ -40,6 +40,8 @@ case class NpsSchemeMembership(startDate: NpsDate, endDate: Option[NpsDate]) {
 object NpsSchemeMembership {
   implicit val formats: Format[NpsSchemeMembership] = (
     (__ \ "scheme_mem_start_date").format[NpsDate] and
-      (__ \ "scheme_end_date").format[Option[NpsDate]]
+    (__ \ "scheme_end_date").format[Option[NpsDate]] and
+    (__ \ "scheme_membership_seq_no").format[Int] and
+    (__ \ "scheme_memb_occ_no").format[Int]
     )(NpsSchemeMembership.apply, unlift(NpsSchemeMembership.unapply))
 }

--- a/app/uk/gov/hmrc/nisp/utils/NISPConstants.scala
+++ b/app/uk/gov/hmrc/nisp/utils/NISPConstants.scala
@@ -74,4 +74,6 @@ object NISPConstants {
   val niRecordMinAge = 16
 
   val homeResponsibilitiesProtectionTypes = List(14, 15, 16, 38, 48, 80)
+
+  val contractedOutEndDate: LocalDate = new LocalDate(newStatePensionStartYear, taxYearStartEndMonth, taxYearEndDay)
 }

--- a/test/resources/regular/schememembership.json
+++ b/test/resources/regular/schememembership.json
@@ -9,6 +9,13 @@
       "scheme_membership_seq_no": 1
     },
     {
+      "scheme_end_date": "1997-06-30",
+      "date_of_election": null,
+      "scheme_mem_start_date": "1978-04-06",
+      "scheme_memb_occ_no": 2,
+      "scheme_membership_seq_no": 1
+    },
+    {
       "scheme_end_date": null,
       "date_of_election": null,
       "scheme_mem_start_date": "1999-04-06",

--- a/test/uk/gov/hmrc/nisp/cache/SchemeMembershipRepositorySpec.scala
+++ b/test/uk/gov/hmrc/nisp/cache/SchemeMembershipRepositorySpec.scala
@@ -36,8 +36,8 @@ class SchemeMembershipRepositorySpec extends UnitSpec with OneServerPerSuite wit
 
   val testSchemeMembershipModel = NpsSchemeMembershipContainer(
     List(
-      NpsSchemeMembership(NpsDate(1980, 4, 6), None),
-      NpsSchemeMembership(NpsDate(1975, 4, 6), Some(NpsDate(1999, 12, 31)))
+      NpsSchemeMembership(NpsDate(1980, 4, 6), None, 1, 1),
+      NpsSchemeMembership(NpsDate(1975, 4, 6), Some(NpsDate(1999, 12, 31)), 1, 1)
     )
   )
 

--- a/test/uk/gov/hmrc/nisp/controllers/SchemeMembershipControllerSpec.scala
+++ b/test/uk/gov/hmrc/nisp/controllers/SchemeMembershipControllerSpec.scala
@@ -46,10 +46,14 @@ class SchemeMembershipControllerSpec  extends UnitSpec with OneAppPerSuite {
     status(result) should be (Status.NOT_FOUND)
   }
 
-  "return JSON list of SchemeMembership details in reverse date order and should return end date as April 2016 when its null" in {
+  "return JSON list of SchemeMembership details for the contracted out user" in {
     val result = testSchemeSummaryController.getSchemeSummary(nino)(FakeRequest())
     val rawJson = Json.parse(contentAsString(result))
-    Json.fromJson[List[SchemeMembership]](rawJson).get shouldBe List( SchemeMembership(new LocalDate(1999,4,6), new LocalDate(2016, 4, 5)), SchemeMembership(new LocalDate(1978,4,6), new LocalDate(1997,6,30)))
+    Json.fromJson[List[SchemeMembership]](rawJson).get shouldBe
+      List(
+        SchemeMembership(new LocalDate(1999,4,6), new LocalDate(2016, 4, 5)),
+        SchemeMembership(new LocalDate(1978,4,6), new LocalDate(1997,6,30))
+      )
   }
 
 }

--- a/test/uk/gov/hmrc/nisp/models/nps/NpsSchemeMembershipSpec.scala
+++ b/test/uk/gov/hmrc/nisp/models/nps/NpsSchemeMembershipSpec.scala
@@ -22,46 +22,46 @@ class NpsSchemeMembershipSpec extends UnitSpec {
   "contains" should {
 
     "return false for Start: 01/01/2016 and End: None and Date is 01/01/2000" in {
-      NpsSchemeMembership(NpsDate(2016, 1, 1), None).contains(NpsDate(2000, 1, 1)) shouldBe false
+      NpsSchemeMembership(NpsDate(2016, 1, 1), None, 1, 1).contains(NpsDate(2000, 1, 1)) shouldBe false
     }
 
     "return true for Start: 01/01/2016 and End: None and Date is 01/01/2013" in {
-      NpsSchemeMembership(NpsDate(2016, 1, 1), None).contains(NpsDate(2013, 1, 1)) shouldBe false
+      NpsSchemeMembership(NpsDate(2016, 1, 1), None, 1, 1).contains(NpsDate(2013, 1, 1)) shouldBe false
     }
 
     "return true for Start: 01/01/2015 and End: 01/01/2016 and Date is 01/01/2016" in {
-      NpsSchemeMembership(NpsDate(2015, 1, 1), Some(NpsDate(2016, 1, 1))).contains(NpsDate(2016, 1, 1)) shouldBe true
+      NpsSchemeMembership(NpsDate(2015, 1, 1), Some(NpsDate(2016, 1, 1)), 1, 1).contains(NpsDate(2016, 1, 1)) shouldBe true
     }
 
     "return false for Start: 01/01/2015 and End: 01/01/2016 and Date is 02/01/2016" in {
-      NpsSchemeMembership(NpsDate(2015, 1, 1), Some(NpsDate(2016, 1, 1))).contains(NpsDate(2016, 1, 2)) shouldBe false
+      NpsSchemeMembership(NpsDate(2015, 1, 1), Some(NpsDate(2016, 1, 1)), 1, 1).contains(NpsDate(2016, 1, 2)) shouldBe false
     }
   }
 
   "exists in tax year" should {
 
     "return true for Start: 2014-4-5 and End: None, taxyear 2013" in {
-      NpsSchemeMembership(NpsDate(2014,4,5), None).existsInTaxYear(2013) shouldBe true
+      NpsSchemeMembership(NpsDate(2014,4,5), None, 1, 1).existsInTaxYear(2013) shouldBe true
     }
 
     "return false for Start: 2014-4-6 and End: None, taxyear 2013" in {
-      NpsSchemeMembership(NpsDate(2014,4,6), None).existsInTaxYear(2013) shouldBe false
+      NpsSchemeMembership(NpsDate(2014,4,6), None, 1, 1).existsInTaxYear(2013) shouldBe false
     }
 
     "return true for Start: 2013-4-5 and End: 2013-4-6, taxyear 2013" in {
-      NpsSchemeMembership(NpsDate(2013,4,5), Some(NpsDate(2013,4,6))).existsInTaxYear(2013) shouldBe true
+      NpsSchemeMembership(NpsDate(2013,4,5), Some(NpsDate(2013,4,6)), 1, 1).existsInTaxYear(2013) shouldBe true
     }
 
     "return false for Start: 2013-4-5 and End: 2013-4-5, taxyear 2013" in {
-      NpsSchemeMembership(NpsDate(2013,4,5), Some(NpsDate(2013,4,5))).existsInTaxYear(2013) shouldBe false
+      NpsSchemeMembership(NpsDate(2013,4,5), Some(NpsDate(2013,4,5)), 1, 1).existsInTaxYear(2013) shouldBe false
     }
 
     "return true for Start: 2013-5-5 and End: 2013-6-5, taxyear 2013" in {
-      NpsSchemeMembership(NpsDate(2013,5,5), Some(NpsDate(2013,6,5))).existsInTaxYear(2013) shouldBe true
+      NpsSchemeMembership(NpsDate(2013,5,5), Some(NpsDate(2013,6,5)), 1, 1).existsInTaxYear(2013) shouldBe true
     }
 
     "return true for Start: 2013-5-5 and End: 2013-6-5, taxyear 2014" in {
-      NpsSchemeMembership(NpsDate(2013,5,5), Some(NpsDate(2013,6,5))).existsInTaxYear(2013) shouldBe true
+      NpsSchemeMembership(NpsDate(2013,5,5), Some(NpsDate(2013,6,5)), 1, 1).existsInTaxYear(2013) shouldBe true
     }
   }
 }

--- a/test/uk/gov/hmrc/nisp/services/ForecastingServiceSpec.scala
+++ b/test/uk/gov/hmrc/nisp/services/ForecastingServiceSpec.scala
@@ -399,37 +399,37 @@ class ForecastingServiceSpec extends UnitSpec with OneAppPerSuite {
 
     "not return forecast amount 1234 with scheme membership that has ended" in {
       StubForecastingService.getForecastAmount(List(
-        NpsSchemeMembership(NpsDate(2010,3,5), Some(NpsDate(2011,3,5)))
+        NpsSchemeMembership(NpsDate(2010,3,5), Some(NpsDate(2011,3,5)), 1, 1)
       ), NpsDate(2013,4,5), 0, npsAmountA2016(), npsAmountB2016, 0, 0, 1234, 0, lastYearQualifying = true, testNino, 0, SPAmountModel(0))(hc).forecastAmount should not be SPAmountModel(1234)
     }
 
     "not return forecast amount 1234 with scheme membership that ends on 2012-04-04, earnings included up to 2013-04-05" in {
       StubForecastingService.getForecastAmount(List(
-        NpsSchemeMembership(NpsDate(2012,3,4), Some(NpsDate(2012,4,4)))
+        NpsSchemeMembership(NpsDate(2012,3,4), Some(NpsDate(2012,4,4)), 1, 1)
       ), NpsDate(2013,4,5), 0, npsAmountA2016(), npsAmountB2016, 0, 0, 1234, 0, lastYearQualifying = true, testNino, 0, SPAmountModel(0))(hc).forecastAmount should not be SPAmountModel(1234)
     }
 
     "not return forecast amount 1234 with scheme membership that ends on 2013-04-05, earnings included up to 2013-04-05" in {
       StubForecastingService.getForecastAmount(List(
-        NpsSchemeMembership(NpsDate(2013,3,5), Some(NpsDate(2013,4,5)))
+        NpsSchemeMembership(NpsDate(2013,3,5), Some(NpsDate(2013,4,5)), 1, 1)
       ), NpsDate(2013,4,5), 0, npsAmountA2016(), npsAmountB2016, 0, 0, 1234, 0, lastYearQualifying = true, testNino, 0, SPAmountModel(0))(hc).forecastAmount should not be SPAmountModel(1234)
     }
 
     "not return forecast amount 1234 with scheme membership that ends on 2013-04-06, earnings included up to 2013-04-05" in {
       StubForecastingService.getForecastAmount(List(
-        NpsSchemeMembership(NpsDate(2012,3,5), Some(NpsDate(2013,4,6)))
+        NpsSchemeMembership(NpsDate(2012,3,5), Some(NpsDate(2013,4,6)), 1, 1)
       ), NpsDate(2013,4,5), 0, npsAmountA2016(), npsAmountB2016, 0, 0, 1234, 0, lastYearQualifying = true, testNino, 0, SPAmountModel(0))(hc).forecastAmount should not be SPAmountModel(1234)
     }
 
     "return 53.31 for scheme membership in last tax year (not at end), 8 QYs" in {
       StubForecastingService.getForecastAmount(List(
-        NpsSchemeMembership(NpsDate(2013,5,5), Some(NpsDate(2013,8,8)))
+        NpsSchemeMembership(NpsDate(2013,5,5), Some(NpsDate(2013,8,8)), 1, 1)
       ), NpsDate(2014,4,5), 8, npsAmountA2016(10), npsAmountB2016, 0, 2015, 0, 0, lastYearQualifying = true, testNino, 0, SPAmountModel(0))(hc).forecastAmount shouldBe SPAmountModel(53.31)
     }
 
     "return 222.06 for 10000 last year earnings, 2013/14 last year, 35QYs, 2016 FRY, existing AP 100" in {
       StubForecastingService.getForecastAmount(
-        List(NpsSchemeMembership(NpsDate(2012,5,5),Some(NpsDate(2014,8,8)))),
+        List(NpsSchemeMembership(NpsDate(2012,5,5),Some(NpsDate(2014,8,8)), 1, 1)),
         NpsDate(2014,4,5), 35, npsAmountA2016(100), npsAmountB2016, 10000, 2016, 0, 0, lastYearQualifying = true, testNino,
       0, SPAmountModel(0))(hc).forecastAmount shouldBe SPAmountModel(222.06)
     }
@@ -461,7 +461,7 @@ class ForecastingServiceSpec extends UnitSpec with OneAppPerSuite {
 
     "return Forecast Only Scenario 111.18 Forecast, 120.07 Max  with 5 years when 2013/14 last year, contracted in, *, 2018 FRY" in {
       StubForecastingService.getForecastAmount(
-        List(NpsSchemeMembership(NpsDate(2012,3,5), Some(NpsDate(2014,4,6)))), NpsDate(2014, 4, 5), 35, npsAmountA2016(0), npsAmountB2016, 10000, 2015, 0, 0, lastYearQualifying = true, testNino,
+        List(NpsSchemeMembership(NpsDate(2012,3,5), Some(NpsDate(2014,4,6)), 1, 1)), NpsDate(2014, 4, 5), 35, npsAmountA2016(0), npsAmountB2016, 10000, 2015, 0, 0, lastYearQualifying = true, testNino,
         0, SPAmountModel(155.65))(hc) shouldBe SPForecastModel(SPAmountModel(154.87), 2, SPAmountModel(154.87), 0, Scenario.ForecastOnly, false)
     }
 

--- a/test/uk/gov/hmrc/nisp/services/SchemeMembershipServiceSpec.scala
+++ b/test/uk/gov/hmrc/nisp/services/SchemeMembershipServiceSpec.scala
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.nisp.services
+
+import org.joda.time.LocalDate
+import org.mockito.Matchers
+import org.mockito.Mockito._
+import org.scalatest.BeforeAndAfter
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.mock.MockitoSugar
+import uk.gov.hmrc.nisp.connectors.NpsConnector
+import uk.gov.hmrc.nisp.helpers.TestAccountBuilder
+import uk.gov.hmrc.nisp.models.SchemeMembership
+import uk.gov.hmrc.nisp.models.nps.{NpsDate, NpsSchemeMembership}
+import uk.gov.hmrc.play.http.HeaderCarrier
+import uk.gov.hmrc.play.test.UnitSpec
+
+import scala.concurrent.Future
+
+class SchemeMembershipServiceSpec extends UnitSpec with MockitoSugar with ScalaFutures {
+
+  val nino = TestAccountBuilder.randomNino()
+  implicit val hc = HeaderCarrier()
+
+  val stubNpsConnector = mock[NpsConnector]
+
+  val stubSchemeMembershipService = new SchemeMembershipService {
+    override val nps: NpsConnector = stubNpsConnector
+  }
+
+  "SchemeMembershipService should" should {
+    "sort the scheme memberships is reverse date order by start date" in {
+      when(stubNpsConnector.connectToSchemeMembership(Matchers.any())(Matchers.any())).thenReturn(
+        Future.successful(List(
+          NpsSchemeMembership(NpsDate(1978, 4, 6), Some(NpsDate(1983, 3, 5)), 1, 1),
+          NpsSchemeMembership(NpsDate(1980, 4, 7), Some(NpsDate(1983, 4, 5)), 2, 1),
+          NpsSchemeMembership(NpsDate(1980, 4, 6), Some(NpsDate(1982, 4, 5)), 3, 1),
+          NpsSchemeMembership(NpsDate(2000, 4, 6), Some(NpsDate(2002, 4, 5)), 4, 1)
+        ))
+      )
+
+      ScalaFutures.whenReady(stubSchemeMembershipService.getSchemeSummary(nino)(hc)) {
+        list => list shouldBe
+          List(
+            SchemeMembership(new LocalDate(2000, 4, 6), new LocalDate(2002, 4, 5)),
+            SchemeMembership(new LocalDate(1980, 4, 7), new LocalDate(1983, 4, 5)),
+            SchemeMembership(new LocalDate(1980, 4, 6), new LocalDate(1982, 4, 5)),
+            SchemeMembership(new LocalDate(1978, 4, 6), new LocalDate(1983, 3, 5))
+          )
+      }
+    }
+
+    "return 5th April 2016 if the Scheme does not have an end date" in {
+      when(stubNpsConnector.connectToSchemeMembership(Matchers.any())(Matchers.any())).thenReturn(
+        Future.successful(List(
+          NpsSchemeMembership(NpsDate(2000, 4, 6), None, 1, 1),
+          NpsSchemeMembership(NpsDate(1980, 4, 7), None, 2, 1)
+        ))
+      )
+
+      ScalaFutures.whenReady(stubSchemeMembershipService.getSchemeSummary(nino)(hc)) {
+        list => list shouldBe
+          List(
+            SchemeMembership(new LocalDate(2000, 4, 6), new LocalDate(2016, 4, 5)),
+            SchemeMembership(new LocalDate(1980, 4, 7), new LocalDate(2016, 4, 5))
+          )
+      }
+    }
+
+    "group the list by sequence number" in {
+      when(stubNpsConnector.connectToSchemeMembership(Matchers.any())(Matchers.any())).thenReturn(
+        Future.successful(List(
+            NpsSchemeMembership(NpsDate(1978, 4, 6), Some(NpsDate(1983, 3, 5)), 1, 1),
+            NpsSchemeMembership(NpsDate(1980, 4, 6), Some(NpsDate(1982, 4, 5)), 2, 1),
+            NpsSchemeMembership(NpsDate(1980, 4, 6), Some(NpsDate(1982, 4, 5)), 2, 2),
+            NpsSchemeMembership(NpsDate(1980, 4, 7), Some(NpsDate(1983, 4, 5)), 3, 1),
+            NpsSchemeMembership(NpsDate(1980, 4, 7), Some(NpsDate(1983, 4, 5)), 3, 2),
+            NpsSchemeMembership(NpsDate(2000, 4, 6), Some(NpsDate(2002, 4, 5)), 4, 1)
+        ))
+      )
+
+      ScalaFutures.whenReady(stubSchemeMembershipService.getSchemeSummary(nino)(hc)) {
+        list => list shouldBe
+          List(
+            SchemeMembership(new LocalDate(2000, 4, 6), new LocalDate(2002, 4, 5)),
+            SchemeMembership(new LocalDate(1980, 4, 7), new LocalDate(1983, 4, 5)),
+            SchemeMembership(new LocalDate(1980, 4, 6), new LocalDate(1982, 4, 5)),
+            SchemeMembership(new LocalDate(1978, 4, 6), new LocalDate(1983, 3, 5))
+          )
+      }
+    }
+
+    "when grouping use the LATEST occurence number in the sequence" in {
+      when(stubNpsConnector.connectToSchemeMembership(Matchers.any())(Matchers.any())).thenReturn(
+        Future.successful(List(
+            NpsSchemeMembership(NpsDate(1978, 4, 6), Some(NpsDate(1983, 3, 5)), 1, 1),
+            NpsSchemeMembership(NpsDate(1980, 4, 6), Some(NpsDate(1982, 4, 5)), 2, 1),
+            NpsSchemeMembership(NpsDate(1980, 4, 6), Some(NpsDate(1982, 4, 6)), 2, 2),
+            NpsSchemeMembership(NpsDate(1980, 4, 7), Some(NpsDate(1983, 4, 6)), 3, 1),
+            NpsSchemeMembership(NpsDate(1980, 4, 7), Some(NpsDate(1983, 4, 5)), 3, 2),
+            NpsSchemeMembership(NpsDate(2000, 4, 6), Some(NpsDate(2002, 4, 5)), 4, 1)
+        ))
+      )
+
+      ScalaFutures.whenReady(stubSchemeMembershipService.getSchemeSummary(nino)(hc)) {
+        list => list shouldBe
+          List(
+            SchemeMembership(new LocalDate(2000, 4, 6), new LocalDate(2002, 4, 5)),
+            SchemeMembership(new LocalDate(1980, 4, 7), new LocalDate(1983, 4, 5)),
+            SchemeMembership(new LocalDate(1980, 4, 6), new LocalDate(1982, 4, 6)),
+            SchemeMembership(new LocalDate(1978, 4, 6), new LocalDate(1983, 3, 5))
+          )
+      }
+    }
+
+  }
+}


### PR DESCRIPTION
The adds Sequence Number and Occurrence Number to the NpsSchemeMembership
Each SchemeMembership is represented by the sequence number. It is possible to have multiple entries for the same SchemeMembership as denoted by the occurrence number. In this case the latest occurrence should be used.