### PR TITLE
NISP-2147: Add dateOfEntry to old model, required by new FE

### DIFF
--- a/app/uk/gov/hmrc/nisp/models/NISummary.scala
+++ b/app/uk/gov/hmrc/nisp/models/NISummary.scala
@@ -32,7 +32,8 @@ case class NISummary(noOfQualifyingYears: Int,
                      isAbroad: Boolean,
                      recordEnd: Option[Int],
                      finalRelevantYear: Int,
-                     homeResponsibilitiesProtection: Boolean)
+                     homeResponsibilitiesProtection: Boolean,
+                     dateOfEntry: NpsDate)
 object NISummary {
   implicit val formats = Json.format[NISummary]
 }

--- a/app/uk/gov/hmrc/nisp/services/NIResponseService.scala
+++ b/app/uk/gov/hmrc/nisp/services/NIResponseService.scala
@@ -91,7 +91,8 @@ trait NIResponseService extends WithCurrentDate {
           npsSummary.isAbroad,
           if(npsSummary.yearsUntilPensionAge <= 0) Some(npsSummary.finalRelevantYear) else None,
           npsSummary.finalRelevantYear,
-          homeResponsibilitiesProtection(npsLiabilities)
+          homeResponsibilitiesProtection(npsLiabilities),
+          npsNIRecord.dateOfEntry
         )
 
         metrics.niRecord(niSummary.noOfNonQualifyingYears, niSummary.numberOfPayableGaps, niSummary.pre75QualifyingYears.getOrElse(0),

--- a/test/uk/gov/hmrc/nisp/services/NIResponseServiceSpec.scala
+++ b/test/uk/gov/hmrc/nisp/services/NIResponseServiceSpec.scala
@@ -45,7 +45,7 @@ class NIResponseServiceSpec  extends UnitSpec with MockitoSugar with BeforeAndAf
     override val citizenDetailsService: CitizenDetailsService = StubCitizenDetailsService
   }
 
-  "customer with NINO regular has date of entry of 01/04/1972" should {
+  "customer with NINO regular has date of entry of 01/10/1973" should {
     "returns NIResponse" in {
       val niResponse = testNIService.getNIResponse(nino)
       niResponse.niRecord.get.taxYears.head shouldBe
@@ -53,6 +53,7 @@ class NIResponseServiceSpec  extends UnitSpec with MockitoSugar with BeforeAndAf
       niResponse.niRecord.get.taxYears.last shouldBe
         NIRecordTaxYear(2013, qualifying = true, 0, 52, 0, 0, None, None, None, payable = false, underInvestigation = false)
       niResponse.niRecord.get.taxYears.size shouldBe 39
+      niResponse.niSummary.get.dateOfEntry shouldBe NpsDate(1973, 10, 1)
     }
   }
 


### PR DESCRIPTION
:see_no_evil: 